### PR TITLE
Fixing heart placement on Events List Page

### DIFF
--- a/src/pages/EventsList.css
+++ b/src/pages/EventsList.css
@@ -20,8 +20,9 @@
 }
 
 .fav-icon {
+    display: flex;
     justify-content: right;
-    display: inline;
+    align-items: center;
 }
 
 .details-card{
@@ -32,3 +33,22 @@
     text-decoration: underline; 
 }
 
+.blockquote {
+    display: grid;
+    grid-template-rows: 2fr 4fr 1fr;
+    grid-template-columns: 4fr 1fr;
+}
+
+.row-2 {
+    grid-column-start: 1;
+    grid-column-end: 3;
+    grid-row-start: 2;
+    grid-row-end: 3;
+}
+
+.row-3 {
+    grid-column-start: 1;
+    grid-column-end: 3;
+    grid-row-start: 3;
+    grid-row-end: 4;
+}

--- a/src/pages/EventsLists.jsx
+++ b/src/pages/EventsLists.jsx
@@ -11,13 +11,14 @@ const EventsList = (props) => {
     <Card className="event-card">
       <Card.Body className="event-body">
         <blockquote className="blockquote mb-0">
-            <Card.Title className="card-title">Marin Food Bank Food Drive <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span></Card.Title>
-          <Card.Text>
+          <Card.Title className="card-title">Marin Food Bank Food Drive </Card.Title>
+          <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span>
+          <Card.Text className="row-2">
             12/9/2022 6:00 AM to 4:00PM 
             <br></br>
             <span className="details-card">http://marinfoodbank.org/events</span>
           </Card.Text>
-          <footer className="blockquote-footer">
+          <footer className="blockquote-footer row-3">
             <span><img src="https://cdn-icons-png.flaticon.com/128/484/484167.png" style={{width: "1.5rem"}}/></span> 1612 Lincoln St, CA San Francisco 94016
           </footer>
         </blockquote>
@@ -27,13 +28,14 @@ const EventsList = (props) => {
          <Card className="event-card">
       <Card.Body className="event-body">
         <blockquote className="blockquote mb-0">
-            <Card.Title>Mission Food Hub Meal Service <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span></Card.Title>
-          <Card.Text>
+          <Card.Title>Mission Food Hub Meal Service </Card.Title>
+          <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span>
+          <Card.Text className="row-2">
             12/9/2022 9:00 AM to 9:45 AM 
             <br></br>
             <span className="details-card">Mission Food Hub will be distrubuting Grab&Go meals provided by Second Harvest.</span>
           </Card.Text>
-          <footer className="blockquote-footer">
+          <footer className="blockquote-footer row-3">
           <span><img src="https://cdn-icons-png.flaticon.com/128/484/484167.png" style={{width: "1.5rem"}}/></span> 1923 Jackson St, CA San Francisco 94016
           </footer>
         </blockquote>
@@ -45,13 +47,14 @@ const EventsList = (props) => {
     <Card className = "event-card">
       <Card.Body className="event-body">
         <blockquote className="blockquote mb-0">
-            <Card.Title>Alta Plaza Park Meal Service: SE corner <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span></Card.Title>
-          <Card.Text>
+          <Card.Title>Alta Plaza Park Meal Service: SE corner </Card.Title>
+          <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span>
+          <Card.Text className="row-2">
             12/10/2022 6:00 AM to 4:00 PM
             <br></br>
             <span className="details-card">Alta Plaza Parks & Recreation will be distrubting Grab&Go meals provided by Feed America </span>
           </Card.Text>
-          <footer className="blockquote-footer">
+          <footer className="blockquote-footer row-3">
           <span><img src="https://cdn-icons-png.flaticon.com/128/484/484167.png" style={{width: "1.5rem"}}/></span> 3749 27th, CA San Francisco 94016
           </footer>
         </blockquote>
@@ -61,13 +64,14 @@ const EventsList = (props) => {
     <Card className = "event-card">
       <Card.Body className="event-body">
         <blockquote className="blockquote mb-0">
-            <Card.Title>Marin Food Bank Food Drive <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span></Card.Title>
-          <Card.Text>
+          <Card.Title>Marin Food Bank Food Drive </Card.Title>
+          <span className="fav-icon"><img src="https://cdn-icons-png.flaticon.com/128/1000/1000621.png" style={{width: "2rem"}}/></span>
+          <Card.Text className="row-2">
             12/9/2022 6:00 AM to 4:00 PM
             <br></br>
             <span className="details-card">http://marinfoodbank.org/events</span>
           </Card.Text>
-          <footer className="blockquote-footer">
+          <footer className="blockquote-footer row-3">
           <span><img src="https://cdn-icons-png.flaticon.com/128/484/484167.png" style={{width: "1.5rem"}}/></span> 2039 35th, CA San Francisco 94016
           </footer>
         </blockquote>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,33 +3,7 @@ import "./HomePage.css";
 
 export default function HomePage(props) {
     return (
-        <div className="homepage">
-            <h1>Welcome!</h1>
-            <SearchBar />
-            <h2>Pop Up Pantries Nearby</h2>
-            <div className="popup-cards">
-                <div className="pop-categories">
-                    <h2>Pop Up Pantry #1</h2>
-                </div>
-                <div className="pop-categories">
-                    <h2>Pop Up Pantry #2</h2>
-                </div>
-                <div className="pop-categories">
-                    <h2>Pop Up Pantry #2</h2>
-                </div>
-            </div>
-            <div className="near-me-cards">
-                <div className="near-me-categories">
-                    <h2>Food Near Me</h2>
-                </div>
-                <div className="near-me-categories">
-                    <h2>Groceries Near Me</h2>
-                </div>
-                <div className="near-me-categories">
-                    <h2>SNAP Retailers</h2>
-                </div>
-            </div>
-            
-        </div>
+        <>
+        </>
     )
 }


### PR DESCRIPTION
Turning event cards into grid so we can adjust the heart placement so it sits on the side of the box, not moving onto the next line.